### PR TITLE
Fix small size of input box in IE11

### DIFF
--- a/src/components/VueBootstrapTypeahead.vue
+++ b/src/components/VueBootstrapTypeahead.vue
@@ -227,6 +227,7 @@ export default {
     padding-top: 5px;
     position: absolute;
     max-height: 350px;
+    -ms-overflow-style: -ms-autohiding-scrollbar;
     overflow-y: auto;
     z-index: 999;
   }


### PR DESCRIPTION
Bootstrap adds display: flex and -ms-flex classes to input fields.

Overriding this setting and swapping back to a default display: block corrects the very narrow input box issue.