### PR TITLE
Better keyboard support

### DIFF
--- a/src/components/VueBootstrapTypeahead.vue
+++ b/src/components/VueBootstrapTypeahead.vue
@@ -16,6 +16,7 @@
         @focus="isFocused = true"
         @blur="handleBlur"
         @input="handleInput($event.target.value)"
+        @keyup.esc="handleEsc($event.target.value)"
         @keyup.down="$emit('keyup.down', $event.target.value)"
         @keyup.up="$emit('keyup.up', $event.target.value)"
         @keyup.enter="$emit('keyup.enter', $event.target.value)"
@@ -40,6 +41,7 @@
       :showOnFocus="showOnFocus"
       :showAllResults="showAllResults"
       @hit="handleHit"
+      @listItemBlur="handleChildBlur"
     >
       <!-- pass down all scoped slots -->
       <template v-for="(slot, slotName) in $scopedSlots" :slot="slotName" slot-scope="{ data, htmlText }">
@@ -156,6 +158,11 @@ export default {
       this.isFocused = false
     },
 
+    handleChildBlur() {
+      this.$refs.input.focus();
+      this.isFocused=false;
+    },
+
     handleBlur(evt) {
       const tgt = evt.relatedTarget
       if (tgt && tgt.classList.contains('vbst-item')) {
@@ -165,11 +172,20 @@ export default {
     },
 
     handleInput(newValue) {
+      this.isFocused = true
       this.inputValue = newValue
 
       // If v-model is being used, emit an input event
       if (typeof this.value !== 'undefined') {
         this.$emit('input', newValue)
+      }
+    },
+
+    handleEsc(inputValue){
+      if(inputValue===""){
+        this.isFocused=false;
+      } else {
+        this.inputValue=''
       }
     }
   },

--- a/src/components/VueBootstrapTypeaheadList.vue
+++ b/src/components/VueBootstrapTypeaheadList.vue
@@ -8,6 +8,7 @@
       :background-variant="backgroundVariant"
       :text-variant="textVariant"
       @click.native="handleHit(item, $event)"
+      v-on="$listeners"
     >
       <template v-if="$scopedSlots.suggestion" slot="suggestion" slot-scope="{ data, htmlText }">
         <slot name="suggestion" v-bind="{ data, htmlText }" />
@@ -151,6 +152,9 @@ export default {
   },
   watch: {
     activeListItem(newValue, oldValue) {
+      if (this.$parent.isFocused==false){
+        this.$parent.isFocused = true
+      }
       if (newValue >= 0) {
         const scrollContainer = this.$refs.suggestionList
         const listItem = scrollContainer.children[this.activeListItem]
@@ -164,6 +168,7 @@ export default {
         } else {
           scrollContainer.scrollTop = 0
         }
+        listItem.focus()
       }
     }
   }

--- a/src/components/VueBootstrapTypeaheadListItem.vue
+++ b/src/components/VueBootstrapTypeaheadListItem.vue
@@ -1,5 +1,11 @@
 <template>
   <a
+    @keydown.tab="$emit('listItemBlur')"
+    @keydown.esc.stop.prevent="$emit('listItemBlur')"
+    @keydown.down.prevent
+    @keydown.up.prevent
+    @keyup.down="$parent.selectNextListItem($event)"
+    @keyup.up="$parent.selectPreviousListItem($event)"
     tabindex="0"
     href="#"
     :class="textClasses"
@@ -33,7 +39,6 @@ export default {
   computed: {
     textClasses() {
       const classes = ['vbst-item', 'list-group-item', 'list-group-item-action']
-      if (this.active) classes.push('active')
       if (this.backgroundVariant) classes.push(`bg-${this.backgroundVariant}`)
       if (this.textVariant) classes.push(`text-${this.textVariant}`)
       return classes.join(' ')


### PR DESCRIPTION
Bootstrap Style
Follow BS patterns and stop using `.active` to style when using the
keyboard to navigate. When using the arrow keys, the list items gain
`:focus`.

This makes handles future keypresses more difficult because you have to
detect them on the list item (grandchildren of the main component).
Additionally, you have to stop the arrow keys on keydown (not keyup
because it's too late) from scrolling the list.

ESC Press
I tried to just "do the right thing" in all cases, but there are many
cases to consider: open/closed, characters typed, arrow-ing up/down,
`showOnFocus` true/false.

TAB Press
This one has few cases, but need to ensure the browser is allowed to
move focus to the next item, so respond to the event, but don't stop it,
allow the browser to move focus normally after closing the list.

Cases Considered:
* close the list on ESC and TAB
* reopen the list if arrow keys are typed after closing
* ESC after arrowing closes the dropdown
* ESC in the text box clears any typed text
* ESC in the text box when no text is present closes the dropdown

Details:
* use `v-on="$listeners"` to pass listeners through to grandchildren
* must use @keydown (not @keyup) to stop event propagation. @keyup is
too late