### PR TITLE
Keyboard - Fix requiring the up/down arrows to be pressed twice to wrap the scroll position in the list

### DIFF
--- a/src/components/VueBootstrapTypeaheadList.vue
+++ b/src/components/VueBootstrapTypeaheadList.vue
@@ -144,11 +144,11 @@ export default {
       if (this.activeListItem < this.matchedItems.length - 1) {
         this.activeListItem++
       } else {
-        this.activeListItem = -1
+        this.activeListItem = 0
       }
     },
     selectPreviousListItem() {
-      if (this.activeListItem < 0) {
+      if (this.activeListItem <= 0) {
         this.activeListItem = this.matchedItems.length - 1
       } else {
         this.activeListItem--


### PR DESCRIPTION
Thank you for your work on this fork - fixes a lot of the issues with the original library 👍 

During testing I found that when navigating the dropdown list via keyboard up/down arrows it would allow me to press up on the first item to wrap around to the last item on the list (and vice-versa). However weirdly it requires me to hit the up/down key twice in order to do so.

This pull request fixes `activeListItem` index being set to -1 when moving beyond the
beginning (or end) of the dropdown list which fixes this behavior.