### PR TITLE
Add focus event

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ Name | Description
 --- | ---
 `hit` | Triggered when an autocomplete item is selected. The entry in the input `data` array that was selected is returned.
 `input` | The component can be used with `v-model`
+`focus` | Triggered focus event trigered on `input` element.
 
 ### Slots
 

--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ showOnFocus | `Boolean` | false | Show results as soon as the input gains focus 
 showAllResults | `Boolean` | false | Show all results even ones that highlighting doesn't match. This is useful when interacting with a API that returns results based on different values than what is displayed. Ex: user searches for "USA" and the service returns "United States of America".
 prepend | `String` | | Text to be prepended to the `input-group`
 append | `String` | | Text to be appended to the `input-group`
+id | `String` | Id for `input` element
 
 ### Events
 Name | Description

--- a/src/components/VueBootstrapTypeahead.vue
+++ b/src/components/VueBootstrapTypeahead.vue
@@ -9,6 +9,7 @@
       <input
         ref="input"
         type="search"
+        :id="id"
         :class="`form-control ${inputClass}`"
         :placeholder="placeholder"
         :aria-label="placeholder"
@@ -114,7 +115,8 @@ export default {
     },
     placeholder: String,
     prepend: String,
-    append: String
+    append: String,
+    id: String
   },
 
   computed: {

--- a/src/components/VueBootstrapTypeahead.vue
+++ b/src/components/VueBootstrapTypeahead.vue
@@ -13,7 +13,7 @@
         :placeholder="placeholder"
         :aria-label="placeholder"
         :value="inputValue"
-        @focus="isFocused = true"
+        @focus="handleFocus"
         @blur="handleBlur"
         @input="handleInput($event.target.value)"
         @keyup.esc="handleEsc($event.target.value)"
@@ -150,6 +150,11 @@ export default {
         const prependRect = this.$refs.prependDiv.getBoundingClientRect()
         listStyle.marginLeft = prependRect.width + 'px'
       }
+    },
+
+    handleFocus() {
+      this.$emit('focus')
+      this.isFocused = true
     },
 
     handleHit(evt) {


### PR DESCRIPTION
Focus event may be useful for loading initial data for list instead of using `mounted` hook for that case.

Also I added `id` attribute for input for use with `<label for="...">`.