### PR TITLE
Added Custom Highlight CSS Class option

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ showOnFocus | `Boolean` | false | Show results as soon as the input gains focus 
 showAllResults | `Boolean` | false | Show all results even ones that highlighting doesn't match. This is useful when interacting with a API that returns results based on different values than what is displayed. Ex: user searches for "USA" and the service returns "United States of America".
 prepend | `String` | | Text to be prepended to the `input-group`
 append | `String` | | Text to be appended to the `input-group`
-highlightClass | `String` | Highlighted text is bold | CSS class to style highlighted text 
+highlightClass | `String` | `vbt-matched-text` | CSS class to style highlighted text 
 
 ### Events
 Name | Description

--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ showOnFocus | `Boolean` | false | Show results as soon as the input gains focus 
 showAllResults | `Boolean` | false | Show all results even ones that highlighting doesn't match. This is useful when interacting with a API that returns results based on different values than what is displayed. Ex: user searches for "USA" and the service returns "United States of America".
 prepend | `String` | | Text to be prepended to the `input-group`
 append | `String` | | Text to be appended to the `input-group`
+highlightClass | `String` | Highlighted text is bold | CSS class to style highlighted text 
 
 ### Events
 Name | Description

--- a/src/components/VueBootstrapTypeahead.vue
+++ b/src/components/VueBootstrapTypeahead.vue
@@ -116,10 +116,7 @@ export default {
     placeholder: String,
     prepend: String,
     append: String,
-    highlightClass: {
-      type: String,
-      default: ''
-    }
+    highlightClass: String
   },
 
   computed: {
@@ -235,5 +232,8 @@ export default {
     -ms-overflow-style: -ms-autohiding-scrollbar;
     overflow-y: auto;
     z-index: 999;
+  }
+  .vbt-autcomplete-list >>> .vbt-matched-text{
+    font-weight: bold;
   }
 </style>

--- a/src/components/VueBootstrapTypeahead.vue
+++ b/src/components/VueBootstrapTypeahead.vue
@@ -43,6 +43,7 @@
       :showAllResults="showAllResults"
       @hit="handleHit"
       @listItemBlur="handleChildBlur"
+      :highlightClass='highlightClass'
     >
       <!-- pass down all scoped slots -->
       <template v-for="(slot, slotName) in $scopedSlots" :slot="slotName" slot-scope="{ data, htmlText }">
@@ -114,7 +115,11 @@ export default {
     },
     placeholder: String,
     prepend: String,
-    append: String
+    append: String,
+    highlightClass: {
+      type: String,
+      default: ''
+    }
   },
 
   computed: {

--- a/src/components/VueBootstrapTypeaheadList.vue
+++ b/src/components/VueBootstrapTypeaheadList.vue
@@ -72,7 +72,7 @@ export default {
     },
     highlightClass: {
       type: String,
-      default: ''
+      default: 'vbt-matched-text'
     }
   },
 
@@ -96,8 +96,7 @@ export default {
           return text
         }
         const re = new RegExp(this.escapedQuery, 'gi')
-        const style = this.highlightClass === '' ? `style='font-weight: bold;'` : `class='${this.highlightClass}'`
-        return text.replace(re, `<span ${style}>$&</span>`)
+        return text.replace(re, `<span class='${this.highlightClass}'>$&</span>`)
       }
     },
 

--- a/src/components/VueBootstrapTypeaheadList.vue
+++ b/src/components/VueBootstrapTypeaheadList.vue
@@ -69,6 +69,10 @@ export default {
     showAllResults: {
       type: Boolean,
       default: false
+    },
+    highlightClass: {
+      type: String,
+      default: ''
     }
   },
 
@@ -92,8 +96,8 @@ export default {
           return text
         }
         const re = new RegExp(this.escapedQuery, 'gi')
-
-        return text.replace(re, `<strong>$&</strong>`)
+        const style = this.highlightClass === '' ? `style='font-weight: bold;'` : `class='${this.highlightClass}'`
+        return text.replace(re, `<span ${style}>$&</span>`)
       }
     },
 

--- a/tests/unit/VueBootstrapTypeaheadList.spec.js
+++ b/tests/unit/VueBootstrapTypeaheadList.spec.js
@@ -74,10 +74,18 @@ describe('VueBootstrapTypeaheadList', () => {
     expect(wrapper.findAll(VueBootstrapTypeaheadListItem).length).toBe(3)
   })
 
-  it('Highlights text matches properly', () => {
+  it('Highlights text matches properly by default', () => {
     wrapper.setProps({
       query: 'Canada'
     })
-    expect(wrapper.find(VueBootstrapTypeaheadListItem).vm.htmlText).toBe('<strong>Canada</strong>')
+    expect(wrapper.find(VueBootstrapTypeaheadListItem).vm.htmlText).toBe(`<span style='font-weight: bold;'>Canada</span>`)
+  })
+
+  it('Highlights text matches properly with highlightClass prop', () => {
+    wrapper.setProps({
+      query: 'Canada',
+      highlightClass: 'myStyle'
+    })
+    expect(wrapper.find(VueBootstrapTypeaheadListItem).vm.htmlText).toBe(`<span class='myStyle'>Canada</span>`)
   })
 })

--- a/tests/unit/VueBootstrapTypeaheadList.spec.js
+++ b/tests/unit/VueBootstrapTypeaheadList.spec.js
@@ -78,7 +78,7 @@ describe('VueBootstrapTypeaheadList', () => {
     wrapper.setProps({
       query: 'Canada'
     })
-    expect(wrapper.find(VueBootstrapTypeaheadListItem).vm.htmlText).toBe(`<span style='font-weight: bold;'>Canada</span>`)
+    expect(wrapper.find(VueBootstrapTypeaheadListItem).vm.htmlText).toBe(`<span class='vbt-matched-text'>Canada</span>`)
   })
 
   it('Highlights text matches properly with highlightClass prop', () => {


### PR DESCRIPTION
# Added Prop to change styling of highlighted text
The highlighted text used to be wrapped in a strong tag - now it is wrapped in a div with a style of 'font-weight: bold;' by default.
If the highlighted class prop is filled out this will be replaced with the CSS class that has been inputted.
### Example Usage
In the `<template>`
```html
<vue-bootstrap-typeahead
      highlightClass='myclass'
    />
```
In the CSS
```css
.myStyle{
  text-decoration: underline;
}
```


# Updated Unit tests 
Include new highlight class prop and change expected default highlighted text

# Updated README 
Include new prop

This was in response to issue #16 