### PR TITLE
ESC while the dropdown is open will no longer clear the input value

### DIFF
--- a/src/components/VueBootstrapTypeahead.vue
+++ b/src/components/VueBootstrapTypeahead.vue
@@ -16,7 +16,7 @@
         @focus="isFocused = true"
         @blur="handleBlur"
         @input="handleInput($event.target.value)"
-        @keyup.esc="handleEsc($event.target.value)"
+        @keydown.esc="handleEsc($event.target.value)"
         @keyup.down="$emit('keyup.down', $event.target.value)"
         @keyup.up="$emit('keyup.up', $event.target.value)"
         @keyup.enter="$emit('keyup.enter', $event.target.value)"


### PR DESCRIPTION
Unless ESC is pressed a 2nd time.

This fixes the incorrect behavior you described here:
https://github.com/mattzollinhofer/vue-typeahead-bootstrap/pull/7#issuecomment-611702629