### PR TITLE
Fix pressing ESC with no input does not clear input focus

### DIFF
--- a/src/components/VueBootstrapTypeahead.vue
+++ b/src/components/VueBootstrapTypeahead.vue
@@ -190,6 +190,7 @@ export default {
 
     handleEsc(inputValue) {
       if (inputValue === '') {
+        this.$refs.input.blur()
         this.isFocused = false
       } else {
         this.inputValue = ''


### PR DESCRIPTION
When setting the `showOnFocus` prop the dropdown will open as soon as the input is clicked on which is nice.

However if you then press ESC it will close the dropdown but retain focus on the input meaning when you click the input again the dropdown will not show as expected.

This small change fixes that behavior. Input blurring has been done for some other interactions just not on ESC for some reason.