### PR TITLE
Added new autoClose prop (defaults to true)

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ inputClass | `String` | | Class to the added to the `input` tag for validation, 
 maxMatches | `Number` | 10 | Maximum amount of list items to appear.
 minMatchingChars | `Number` | 2 | Minimum matching characters in query before the typeahead list appears
 showOnFocus | `Boolean` | false | Show results as soon as the input gains focus before the user has typed anything.
+autoClose | `Boolean` | true | Whether the autocomplete should hide upon item selection
 showAllResults | `Boolean` | false | Show all results even ones that highlighting doesn't match. This is useful when interacting with a API that returns results based on different values than what is displayed. Ex: user searches for "USA" and the service returns "United States of America".
 prepend | `String` | | Text to be prepended to the `input-group`
 append | `String` | | Text to be appended to the `input-group`

--- a/src/components/VueBootstrapTypeahead.vue
+++ b/src/components/VueBootstrapTypeahead.vue
@@ -113,6 +113,10 @@ export default {
       type: Boolean,
       default: false
     },
+    autoClose: {
+      type: Boolean,
+      default: true
+    },
     placeholder: String,
     prepend: String,
     append: String,
@@ -161,8 +165,11 @@ export default {
 
       this.inputValue = evt.text
       this.$emit('hit', evt.data)
-      this.$refs.input.blur()
-      this.isFocused = false
+
+      if (this.autoClose) {
+        this.$refs.input.blur()
+        this.isFocused = false
+      }
     },
 
     handleChildBlur() {

--- a/src/components/VueBootstrapTypeaheadList.vue
+++ b/src/components/VueBootstrapTypeaheadList.vue
@@ -160,7 +160,7 @@ export default {
   },
   watch: {
     activeListItem(newValue, oldValue) {
-      if (this.$parent.isFocused === false) {
+      if (!this.$parent.autoClose && this.$parent.isFocused === false) {
         this.$parent.isFocused = true
       }
       if (newValue >= 0) {

--- a/src/views/Reference.vue
+++ b/src/views/Reference.vue
@@ -64,6 +64,20 @@
                 <td>Minimum matching characters in query before the typeahead list appears</td>
               </tr>
               <tr>
+              <tr>
+                <td><code>showOnFocus</code></td>
+                <td>Boolean</td>
+                <td>false</td>
+                <td>Show results as soon as the input gains focus before the user has typed anything</td>
+              </tr>
+              <tr>
+              <tr>
+                <td><code>autoClose</code></td>
+                <td>Boolean</td>
+                <td>true</td>
+                <td>Whether the autocomplete should hide upon item selection</td>
+              </tr>
+              <tr>
                 <td><code>prepend</code></td>
                 <td>String</td>
                 <td></td>


### PR DESCRIPTION
Added new autoClose prop (defaults to true) to auto close the dropdown upon item selection. When enabled also ensures `ENTER` on an item after keyboard navigation selects and closes the dropdown as well (as per original my pull request #7)