### PR TITLE
Add support for disabling list items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.4.0 - 05 Jul 2020
+- Add the ability to disable list items
+
 ## 2.3.0 - 18 Jun 2020
 - Add support for inputName
 

--- a/docs/.vuepress/components/APIExample.vue
+++ b/docs/.vuepress/components/APIExample.vue
@@ -6,6 +6,7 @@
       :data="users"
       :serializer="item => item.login"
       @hit="selecteduser = $event"
+      :disabledValues="(selecteduser ? [selecteduser.login] : [])"
       placeholder="Search Github Users"
       @input="lookupUser"
     />

--- a/docs/.vuepress/components/CustomSuggestion.vue
+++ b/docs/.vuepress/components/CustomSuggestion.vue
@@ -10,6 +10,7 @@
       :minMatchingChars="3"
       placeholder="Search Github Users"
       inputClass="special-input-class"
+      :disabledValues="(selecteduser ? [selecteduser.login] : [])"
       @input="lookupUser"
     >
       <template slot="suggestion" slot-scope="{ data, htmlText }">

--- a/docs/examples/examples.md
+++ b/docs/examples/examples.md
@@ -33,16 +33,17 @@
 ```vue
 <template>
   <div>
-      <vue-typehead-bootstrap
-        class="mb-4"
-        v-model="query"
-        :data="users"
-        :serializer="item => item.login"
-        @hit="selecteduser = $event"
-        placeholder="Search Github Users"
-        @input="lookupUser"
-      />
-      Selected user: <span v-if="selecteduser">{{selecteduser.login}}</span>
+    <vue-typeahead-bootstrap
+      class="mb-4"
+      v-model="query"
+      :data="users"
+      :serializer="item => item.login"
+      @hit="selecteduser = $event"
+      :disabledValues="(selecteduser ? [selecteduser.login] : [])"
+      placeholder="Search Github Users"
+      @input="lookupUser"
+    />
+    Selected user: <span v-if="selecteduser">{{selecteduser.login}}</span>
   </div>
 </template>
 
@@ -131,7 +132,7 @@
 ```vue
 <template>
   <div>
-    <vue-typehead-bootstrap
+    <vue-typeahead-bootstrap
       class="mb-4"
       v-model="query"
       :data="users"
@@ -141,6 +142,7 @@
       :minMatchingChars="3"
       placeholder="Search Github Users"
       inputClass="special-input-class"
+      :disabledValues="(selecteduser ? [selecteduser.login] : [])"
       @input="lookupUser"
     >
       <template slot="suggestion" slot-scope="{ data, htmlText }">

--- a/docs/guide/reference.md
+++ b/docs/guide/reference.md
@@ -9,6 +9,7 @@
 | backgroundVariant | String | | Background color for the autocomplete result `list-group` items. [See values here.][1]
 | data | Array | | Array of data to be available for querying. **Required**|
 | disabled | `Boolean` | false | Enable or disable input field
+| disabledValues| `Array` | false | The dropdown items to `disable`.
 | disableSort | `Boolean` | false | If set to true, no sorting occurs and the list is presented to the user as it is given to the component. Use this if you sort the list before giving it to the component. Ex: an elasticsearch result being passed to Vue.
 | highlightClass | `String` | `vbt-matched-text` | CSS class to style highlighted text
 | inputClass | String | | Class to be added to the `input` tag for validation, etc.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-typeahead-bootstrap",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "private": false,
   "description": "A typeahead/autocomplete component for Vue 2 using Bootstrap 4",
   "keywords": [

--- a/src/components/VueTypeaheadBootstrap.vue
+++ b/src/components/VueTypeaheadBootstrap.vue
@@ -46,6 +46,7 @@
       @hit="handleHit"
       @listItemBlur="handleChildBlur"
       :highlightClass='highlightClass'
+      :disabledValues="disabledValues"
     >
       <!-- pass down all scoped slots -->
       <template v-for="(slot, slotName) in $scopedSlots" :slot="slotName" slot-scope="{ data, htmlText }">
@@ -94,6 +95,10 @@ export default {
       validator: d => d instanceof Function
     },
     backgroundVariant: String,
+    disabledValues: {
+      type: Array,
+      default: () => []
+    },
     textVariant: String,
     inputClass: {
       type: String,

--- a/src/components/VueTypeaheadBootstrapListItem.vue
+++ b/src/components/VueTypeaheadBootstrapListItem.vue
@@ -28,6 +28,9 @@ export default {
     htmlText: {
       type: String
     },
+    disabled: {
+      type: Boolean
+    },
     backgroundVariant: {
       type: String
     },
@@ -41,8 +44,19 @@ export default {
       const classes = ['vbst-item', 'list-group-item', 'list-group-item-action']
       if (this.backgroundVariant) classes.push(`bg-${this.backgroundVariant}`)
       if (this.textVariant) classes.push(`text-${this.textVariant}`)
+      if (this.disabled) classes.push('disabled')
       return classes.join(' ')
     }
   }
 }
 </script>
+
+<style scoped>
+  a:not(.disabled){
+    cursor: pointer;
+  }
+  a.disabled{
+    cursor: default;
+    pointer-events: none;
+  }
+</style>

--- a/tests/unit/VueTypeaheadBootstrap.spec.js
+++ b/tests/unit/VueTypeaheadBootstrap.spec.js
@@ -52,7 +52,7 @@ describe('VueTypeaheadBootstrap', () => {
 
   it('Allows for a name to be provided for the input', () => {
     wrapper.setProps({inputName: 'name-is-provided-for-this-input'})
-    expect(wrapper.find("input").attributes().name).toBe('name-is-provided-for-this-input')
+    expect(wrapper.find('input').attributes().name).toBe('name-is-provided-for-this-input')
   })
 
   it('Show the list when given a query', () => {

--- a/tests/unit/VueTypeaheadBootstrapList.spec.js
+++ b/tests/unit/VueTypeaheadBootstrapList.spec.js
@@ -81,6 +81,121 @@ describe('VueBootstrapTypeaheadList', () => {
     expect(wrapper.find(VueTypeaheadBootstrapListItem).vm.htmlText).toBe(`<span class='vbt-matched-text'>Canada</span>`)
   })
 
+  describe('selecting items with the keyboard', () => {
+    beforeEach(() => {
+      wrapper.setProps({
+        data: [
+          {
+            id: 0,
+            data: 'Canada',
+            text: 'Canada'
+          },
+          {
+            id: 1,
+            data: 'Canada1',
+            text: 'Canada1'
+          },
+          {
+            id: 2,
+            data: 'Canada2',
+            text: 'Canada2'
+          }
+        ],
+        query: 'Cana'
+      })
+    })
+
+    describe('using the down arrow', () => {
+      it('cycles through all options', () => {
+        wrapper.vm.selectNextListItem()
+        expect(wrapper.vm.activeListItem).toBe(0)
+        wrapper.vm.selectNextListItem()
+        expect(wrapper.vm.activeListItem).toBe(1)
+        wrapper.vm.selectNextListItem()
+        expect(wrapper.vm.activeListItem).toBe(2)
+      })
+      it('returns the first item when nothing is disabled', () => {
+        wrapper.vm.selectNextListItem()
+        expect(wrapper.vm.activeListItem).toBe(0)
+      })
+      it('returns the second item when the first is disabled', () => {
+        wrapper.setProps({disabledValues: ['Canada']})
+        wrapper.vm.selectNextListItem()
+        expect(wrapper.vm.activeListItem).toBe(1)
+      })
+      it('returns the third item when the first and second are disabled', () => {
+        wrapper.setProps({disabledValues: ['Canada', 'Canada1']})
+        wrapper.vm.selectNextListItem()
+        expect(wrapper.vm.activeListItem).toBe(2)
+      })
+      it('returns -1 when everything is disabled', () => {
+        wrapper.setProps({disabledValues: ['Canada', 'Canada1', 'Canada2']})
+        wrapper.vm.selectNextListItem()
+        expect(wrapper.vm.activeListItem).toBe(-1)
+        wrapper.vm.selectNextListItem()
+        expect(wrapper.vm.activeListItem).toBe(-1)
+      })
+      it('wraps back to the beginning from the end', () => {
+        wrapper.vm.activeListItem = 1
+        wrapper.vm.selectNextListItem()
+        expect(wrapper.vm.activeListItem).toBe(2)
+        wrapper.vm.selectNextListItem()
+        expect(wrapper.vm.activeListItem).toBe(0)
+      })
+      it('wrapping accounts for disabled items', () => {
+        wrapper.setProps({disabledValues: ['Canada']})
+        wrapper.vm.activeListItem = 2
+        wrapper.vm.selectNextListItem()
+        expect(wrapper.vm.activeListItem).toBe(1)
+      })
+    })
+
+    describe('using the up arrow', () => {
+      it('returns the last item when nothing is disabled', () => {
+        wrapper.vm.selectPreviousListItem()
+        expect(wrapper.vm.activeListItem).toBe(2)
+      })
+      it('returns the second item when the last is disabled', () => {
+        wrapper.setProps({disabledValues: ['Canada2']})
+        wrapper.vm.selectPreviousListItem()
+        expect(wrapper.vm.activeListItem).toBe(1)
+      })
+      it('returns the second item when the third and fourth are disabled', () => {
+        wrapper.setProps({disabledValues: ['Canada3', 'Canada2']})
+        wrapper.vm.selectPreviousListItem()
+        expect(wrapper.vm.activeListItem).toBe(1)
+      })
+      it('returns -1 when everything is disabled', () => {
+        wrapper.setProps({disabledValues: ['Canada', 'Canada1', 'Canada2', 'Canada3']})
+        wrapper.vm.selectPreviousListItem()
+        expect(wrapper.vm.activeListItem).toBe(-1)
+        wrapper.vm.selectPreviousListItem()
+        expect(wrapper.vm.activeListItem).toBe(-1)
+      })
+      it('cycles through all options', () => {
+        wrapper.vm.selectPreviousListItem()
+        expect(wrapper.vm.activeListItem).toBe(2)
+        wrapper.vm.selectPreviousListItem()
+        expect(wrapper.vm.activeListItem).toBe(1)
+        wrapper.vm.selectPreviousListItem()
+        expect(wrapper.vm.activeListItem).toBe(0)
+      })
+      it('wraps back to the end from the beginning', () => {
+        wrapper.vm.activeListItem = 1
+        wrapper.vm.selectPreviousListItem()
+        expect(wrapper.vm.activeListItem).toBe(0)
+        wrapper.vm.selectPreviousListItem()
+        expect(wrapper.vm.activeListItem).toBe(2)
+      })
+      it('wrapping accounts for disabled items', () => {
+        wrapper.setProps({disabledValues: ['Canada2']})
+        wrapper.vm.activeListItem = 0
+        wrapper.vm.selectPreviousListItem()
+        expect(wrapper.vm.activeListItem).toBe(1)
+      })
+    })
+  })
+
   it('Highlights text matches properly with highlightClass prop', () => {
     wrapper.setProps({
       query: 'Canada',


### PR DESCRIPTION
When using this component as a multiple selection dropdown, disabling
items is important. For example, if you were populating a list of
countries you'd visited, it wouldn't make sense to select "Italy"
twice. It should naturally be disabled.

* To support this I had to move to the list to be `<button>` based instead
of `<a>` based because `<a>`s do not support the `disabled` attribute.
After looking at it, I think the `<button>` is the more accurate option
anyways because we were never accepting anything as an `href` and always
forcing it to be `#`.

Questions

* I'm still debating the API for this. Currently I"m going with a semantic
type API by calling it `selectedValues` and then just acting by disabling
those elements. But, I wonder if it might be better to call it something
more explicit like `itemsToDisable`.

* I'm also worried that keyboard handing feels a little clunky. It should
just skip the item, but a disabled item is selectable with the arrow keys.

I'm still working through this a little bit, but do either of you (@BozoJim @alpharahl) have any thoughts on the matter?