### PR TITLE
Chore: fix custom serializer test

### DIFF
--- a/tests/unit/VueTypeaheadBootstrap.spec.js
+++ b/tests/unit/VueTypeaheadBootstrap.spec.js
@@ -35,13 +35,15 @@ describe('VueTypeaheadBootstrap', () => {
   })
 
   it('Uses a custom serializer properly', () => {
-    wrapper.setProps({
-      data: [{
-        name: 'Canada',
-        code: 'CA'
-      }],
-      value: 'Can',
-      serializer: t => t.name
+    wrapper = mount(VueTypeaheadBootstrap, {
+      propsData: {
+        data: [{
+          name: 'Canada',
+          code: 'CA'
+        }],
+        value: 'Can',
+        serializer: t => t.name
+      }
     })
     expect(wrapper.vm.formattedData[0].id).toBe(0)
     expect(wrapper.vm.formattedData[0].data.code).toBe('CA')


### PR DESCRIPTION
When running the unit tests (`npm run test:unit`), I got two `TypeError: i.text.match is not a function` errors. These were caused by setting the props with `wrapper.setProps`: first the `data` and `value` prop are set, which both caused computed properties to be recalculated before the new serializer function was set, leading to the error.