### PR TITLE
fix IE click handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.2.0 - 18 Jun 2020
+- Fix IE support for click handling
+- Clean up tests
+
 ## 2.1.0 - 26 May 2020
 - Add disabled option
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-typeahead-bootstrap",
-  "version": "2.1.2",
+  "version": "2.2.0",
   "private": false,
   "description": "A typeahead/autocomplete component for Vue 2 using Bootstrap 4",
   "keywords": [

--- a/src/components/VueTypeaheadBootstrap.vue
+++ b/src/components/VueTypeaheadBootstrap.vue
@@ -15,7 +15,7 @@
         :value="inputValue"
         :disabled="disabled"
         @focus="isFocused = true"
-        @blur="handleBlur"
+        @focusout="handleFocusOut"
         @input="handleInput($event.target.value)"
         @keydown.esc="handleEsc($event.target.value)"
         @keyup.down="$emit('keyup.down', $event.target.value)"
@@ -182,7 +182,7 @@ export default {
       this.isFocused = false
     },
 
-    handleBlur(evt) {
+    handleFocusOut(evt) {
       const tgt = evt.relatedTarget
       if (tgt && tgt.classList.contains('vbst-item')) {
         return

--- a/tests/unit/VueTypeaheadBootstrap.spec.js
+++ b/tests/unit/VueTypeaheadBootstrap.spec.js
@@ -57,12 +57,12 @@ describe('VueTypeaheadBootstrap', () => {
     expect(child.isVisible()).toBe(true)
   })
 
-  it('Hides the list when blurred', () => {
+  it('Hides the list when focus is lost', () => {
     let child = wrapper.find(VueTypeaheadBootstrapList)
     wrapper.setData({inputValue: 'Can'})
     wrapper.find('input').trigger('focus')
     expect(child.isVisible()).toBe(true)
-    wrapper.find('input').trigger('blur')
+    wrapper.find('input').trigger('focusout')
     expect(child.isVisible()).toBe(false)
   })
 


### PR DESCRIPTION
The related target field that chrome/firefox populate on blur events does not appear to be a standard according to the MDN. However they are a standard on the `focusout` event. So by moving over to the `focusout` event we are able to capture the related target field on all tested browsers