### PR TITLE
Fix emit of keyup event

### DIFF
--- a/src/components/VueTypeaheadBootstrap.vue
+++ b/src/components/VueTypeaheadBootstrap.vue
@@ -19,9 +19,7 @@
         @focusout="handleFocusOut"
         @input="handleInput($event.target.value)"
         @keydown.esc="handleEsc($event.target.value)"
-        @keyup.down="$emit('keyup.down', $event.target.value)"
-        @keyup.up="$emit('keyup.up', $event.target.value)"
-        @keyup.enter="$emit('keyup.enter', $event.target.value)"
+        @keyup="$emit('keyup', $event)"
         autocomplete="off"
       />
       <div v-if="$slots.append || append" class="input-group-append">

--- a/tests/unit/VueTypeaheadBootstrap.spec.js
+++ b/tests/unit/VueTypeaheadBootstrap.spec.js
@@ -78,4 +78,12 @@ describe('VueTypeaheadBootstrap', () => {
     })
     expect(wrapper.vm.sizeClasses).toBe('input-group input-group-lg')
   })
+
+  it('Emits a keyup.enter event when enter is pressed on the input field', () => {
+    let input = wrapper.find('input')
+    input.trigger('keyup.enter')
+    expect(wrapper.emitted().keyup).toBeTruthy()
+    expect(wrapper.emitted().keyup.length).toBe(1)
+    expect(wrapper.emitted().keyup[0][0].keyCode).toBe(13)
+  })
 })


### PR DESCRIPTION
This fix enables the keyup.enter event to be listened to. The complete event is emitted instead of only the value. Should fix #59 