### PR TITLE
Update VueTypeaheadBootstrapList.vue

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [ 10.x, 12.x ]
+        node-version: [ 13.x ]
     steps:
       - uses: actions/checkout@v2
       - name: Lint & Test
@@ -29,7 +29,7 @@ jobs:
     needs: test
     strategy:
       matrix:
-        node-version: [ 10.x, 12.x ]
+        node-version: [ 12.x, 13.x ]
     steps:
       - uses: actions/checkout@v2
       - name: Build & Release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.5.4 - 11 Nov 2020
+- Reduced package size
+
 ## 2.5.3.beta - 28 Sep 2020
 - Attempted a11y improvements to use standard combobox aria tags
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-typeahead-bootstrap",
-  "version": "1.0.3",
+  "version": "2.5.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1085,12 +1085,22 @@
       "dev": true
     },
     "@vue/test-utils": {
-      "version": "1.0.0-beta.24",
-      "resolved": "https://registry.npmjs.org/@vue/test-utils/-/test-utils-1.0.0-beta.24.tgz",
-      "integrity": "sha512-GJyoAbyo1rEyohUziouJqDL7Nu7stSl3ByyYXLTppbrwdKZ9fFZPLZwKxkxS/Ks4Fo9YG5lALLLttypz0SC7FA==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@vue/test-utils/-/test-utils-1.1.1.tgz",
+      "integrity": "sha512-/32538ilZ9qSiu1gui7zfBn+IFy+zoTaQTZ1qiLfQXzZtaeAD23kJMrnqaoe2w8JzJoXuqHUl2ruuStG8rwFYQ==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.4"
+        "dom-event-types": "^1.0.0",
+        "lodash": "^4.17.15",
+        "pretty": "^2.0.0"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+          "dev": true
+        }
       }
     },
     "@vue/web-component-wrapper": {
@@ -4635,6 +4645,12 @@
           "dev": true
         }
       }
+    },
+    "dom-event-types": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/dom-event-types/-/dom-event-types-1.0.0.tgz",
+      "integrity": "sha512-2G2Vwi2zXTHBGqXHsJ4+ak/iP0N8Ar+G8a7LiD2oup5o4sQWytwqqrZu/O6hIMV0KMID2PL69OhpshLO0n7UJQ==",
+      "dev": true
     },
     "dom-serializer": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-typeahead-bootstrap",
-  "version": "2.5.3-beta",
+  "version": "2.5.4",
   "private": false,
   "description": "A typeahead/autocomplete component for Vue 2 using Bootstrap 4",
   "keywords": [
@@ -43,7 +43,7 @@
     "@vue/cli-plugin-unit-jest": "^3.0.0",
     "@vue/cli-service": "^3.0.0",
     "@vue/eslint-config-standard": "^3.0.1",
-    "@vue/test-utils": "^1.0.0-beta.20",
+    "@vue/test-utils": "^1.1.1",
     "babel-core": "7.0.0-bridge.0",
     "babel-jest": "^23.0.1",
     "bootstrap": "^4.1.3",

--- a/src/components/VueTypeaheadBootstrapList.vue
+++ b/src/components/VueTypeaheadBootstrapList.vue
@@ -24,7 +24,12 @@
 
 <script>
 import VueTypeaheadBootstrapListItem from './VueTypeaheadBootstrapListItem.vue'
-import { clone, includes, isEmpty, reject, reverse, findIndex } from 'lodash'
+import clone from 'lodash/clone'
+import includes from 'lodash/includes'
+import isEmpty from 'lodash/isEmpty'
+import reject from 'lodash/reject'
+import reverse from 'lodash/reverse'
+import findIndex from 'lodash/findIndex'
 
 const BEFORE_LIST_INDEX = -1
 


### PR DESCRIPTION
Without optimization, this plugin adds 500kb (complete lodash) to the app - https://i.imgur.com/DGhkWKo.png

So, this commit makes the import procedure as it needs to be done per standards. Please see section - Reducing size of lodash : https://medium.com/js-dojo/how-to-reduce-your-vue-js-bundle-size-with-webpack-3145bf5019b7