### PR TITLE
Supporting md as an option on the Typeahead size prop

### DIFF
--- a/docs/guide/reference.md
+++ b/docs/guide/reference.md
@@ -20,7 +20,7 @@
 | serializer | Function | `input => input`| Function used to convert the entries in the data array into a text string. |
 | showAllResults | `Boolean` | false | Show all results even ones that highlighting doesn't match. This is useful when interacting with a API that returns results based on different values than what is displayed. Ex: user searches for "USA" and the service returns "United States of America".
 | showOnFocus | `Boolean` | false | Show results as soon as the input gains focus before the user has typed anything.
-| size | String | | Size of the `input-group`. Valid values: `sm` or `lg` |
+| size | String | | Size of the `input-group`. Valid values: `sm`, `md`, or `lg` |
 | textVariant | String | | Text color for autocomplete result `list-group` items. [See values here.][2]
 
 ## Events

--- a/src/components/VueTypeaheadBootstrap.vue
+++ b/src/components/VueTypeaheadBootstrap.vue
@@ -92,7 +92,7 @@ export default {
     size: {
       type: String,
       default: null,
-      validator: size => ['lg', 'sm'].indexOf(size) > -1
+      validator: size => ['lg', 'md', 'sm'].indexOf(size) > -1
     },
     value: {
       type: String


### PR DESCRIPTION
Closes #96.

Adds `md` as an option in the `size` prop, and updates the documentation accordingly to allow for this size.