### PR TITLE
Feature - list append slot

### DIFF
--- a/docs/.vuepress/components/ListAppend.vue
+++ b/docs/.vuepress/components/ListAppend.vue
@@ -7,7 +7,7 @@
         placeholder="Choose your favorite color"
         @hitListAppend="addColor"
       >
-        <template v-if="query.length > 1" slot="listAppend" :slot-scope="{ query }">
+        <template v-if="query.length > 1" slot="listAppend">
           Add: {{ query }}
         </template>
       </vue-typeahead-bootstrap>

--- a/docs/.vuepress/components/ListAppend.vue
+++ b/docs/.vuepress/components/ListAppend.vue
@@ -1,0 +1,40 @@
+<template>
+  <div>
+    <div class="pl-1 pb-2 pt-3">Selected color: {{query}}</div>
+      <vue-typeahead-bootstrap
+        v-model="query"
+        v-bind="{ data }"
+        placeholder="Choose your favorite color"
+        @hitAppend="addColor"
+      >
+        <template v-if="query.length > 1" slot="listAppend" :slot-scope="{ query }">
+          Add: {{ query }}
+        </template>
+      </vue-typeahead-bootstrap>
+  </div>
+</template>
+
+<script>
+  import 'bootstrap-vue/dist/bootstrap-vue.css'
+  import VueTypeaheadBootstrap from "../../../src/components/VueTypeaheadBootstrap";
+
+  export default {
+    name: "ListAppend",
+    components: {VueTypeaheadBootstrap},
+    data(){
+      return {
+        query: '',
+        data: ['Red', 'Green', 'Blue']
+      }
+    },
+    methods: {
+      addColor(colorName) {
+        this.data.push(colorName)
+      }
+    }
+  }
+</script>
+
+<style lang="scss">
+  @import 'bootstrap/scss/bootstrap.scss';
+</style>

--- a/docs/.vuepress/components/ListAppend.vue
+++ b/docs/.vuepress/components/ListAppend.vue
@@ -5,7 +5,7 @@
         v-model="query"
         v-bind="{ data }"
         placeholder="Choose your favorite color"
-        @hitAppend="addColor"
+        @hitListAppend="addColor"
       >
         <template v-if="query.length > 1" slot="listAppend" :slot-scope="{ query }">
           Add: {{ query }}

--- a/docs/examples/examples.md
+++ b/docs/examples/examples.md
@@ -211,3 +211,41 @@
   }
 </style>
 ```
+
+## List Append Slot
+<ListAppend/>
+
+```vue
+<template>
+  <div class="pl-1 pb-2 pt-3">Selected color: {{query}}</div>
+  <div>
+    Options: `Red, Green, Blue` or add your own,
+    <vue-typeahead-bootstrap
+        v-model="query"
+        v-bind="{ data }"
+        placeholder="Choose your favorite color"
+        @hitAppend="addColor"
+      >
+        <template v-if="query.length > 1" slot="listAppend" :slot-scope="{ query }">
+          Add: {{ query }}
+        </template>
+      </vue-typeahead-bootstrap>
+  </div>
+</template>
+
+<script>
+  export default {
+    data(){
+      return {
+        query: '',
+        data: ['Red', 'Green', 'Blue']
+      }
+    },
+    methods: {
+      addColor(colorName) {
+        this.data.push(colorName)
+      }
+    }
+  }
+</script>
+```

--- a/docs/examples/examples.md
+++ b/docs/examples/examples.md
@@ -226,7 +226,7 @@
         placeholder="Choose your favorite color"
         @hitListAppend="addColor"
       >
-        <template v-if="query.length > 1" slot="listAppend" :slot-scope="{ query }">
+        <template v-if="query.length > 1" slot="listAppend">
           Add: {{ query }}
         </template>
       </vue-typeahead-bootstrap>

--- a/docs/examples/examples.md
+++ b/docs/examples/examples.md
@@ -224,7 +224,7 @@
         v-model="query"
         v-bind="{ data }"
         placeholder="Choose your favorite color"
-        @hitAppend="addColor"
+        @hitListAppend="addColor"
       >
         <template v-if="query.length > 1" slot="listAppend" :slot-scope="{ query }">
           Add: {{ query }}

--- a/docs/guide/reference.md
+++ b/docs/guide/reference.md
@@ -34,13 +34,13 @@ keyup | Triggered when any keyup event is fired in the input. Often used for cat
 
 ## Slots
 
-There are `prepend` and `append` slots available for adding buttons or other markup. Overrides the prepend and append props. 
+There are `prepend` and `append` slots available for adding buttons or other markup. Overrides the prepend and append props.
 
 ### Scoped Slots
 
 You can use a [scoped slot][3] called `suggestion` to define custom content for the suggestion `list-item`'s. You can use bound variables `data`, which holds the data from the input array, and `htmlText`, which is the highlighted text that is used for the suggestion.
 
-Additionaly there is `listAppend` slot, rendered at the end of autocomplete items as item with slot content, when selected emits `hitListAppend` event. Slot has bound variable `query`.
+Additionaly there is the `listAppend` slot, rendered at the end of autocomplete items (as an item with slot content), when selected, emits `hitListAppend` event. Slot has bound variable `query`.
 
 See the [Examples][4] for more info.
 

--- a/docs/guide/reference.md
+++ b/docs/guide/reference.md
@@ -40,7 +40,7 @@ There are `prepend` and `append` slots available for adding buttons or other mar
 
 You can use a [scoped slot][3] called `suggestion` to define custom content for the suggestion `list-item`'s. You can use bound variables `data`, which holds the data from the input array, and `htmlText`, which is the highlighted text that is used for the suggestion.
 
-Additionaly there is the `listAppend` slot, rendered at the end of autocomplete items (as an item with slot content), when selected, emits `hitListAppend` event. Slot has bound variable `query`.
+Additionaly there is the `listAppend` slot, rendered at the end of autocomplete items (as an item with slot content), when selected, emits `hitListAppend` event.
 
 See the [Examples][4] for more info.
 

--- a/docs/guide/reference.md
+++ b/docs/guide/reference.md
@@ -28,20 +28,23 @@
 Name | Description
 | --- | --- |
 hit | Triggered when an autocomplete item is selected. The entry in the input data array that was selected is returned.
+hitListAppend | Triggered when list append item is selected (if `listAppend` slot used). Returns query.
 input | The component can be used with `v-model`
 keyup | Triggered when any keyup event is fired in the input. Often used for catching `keyup.enter`.
 
 ## Slots
 
-There are `prepend` and `append` slots available for adding buttons or other markup. Overrides the prepend and append props.
+There are `prepend` and `append` slots available for adding buttons or other markup. Overrides the prepend and append props. 
 
-### Scoped Slot
+### Scoped Slots
 
 You can use a [scoped slot][3] called `suggestion` to define custom content for the suggestion `list-item`'s. You can use bound variables `data`, which holds the data from the input array, and `htmlText`, which is the highlighted text that is used for the suggestion.
 
-See the [custom suggestion slot example][4] for more info.
+Additionaly there is `listAppend` slot, rendered at the end of autocomplete items as item with slot content, when selected emits `hitListAppend` event. Slot has bound variable `query`.
+
+See the [Examples][4] for more info.
 
 [1]: https://getbootstrap.com/docs/4.1/utilities/colors/#background-color
 [2]: https://getbootstrap.com/docs/4.1/utilities/colors/#color
 [3]: https://vuejs.org/v2/guide/components-slots.html#Scoped-Slots
-[4]: #
+[4]: ../examples/examples.md

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-typeahead-bootstrap",
-  "version": "2.5.4",
+  "version": "2.5.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-typeahead-bootstrap",
-  "version": "2.5.5",
+  "version": "2.6.0",
   "private": false,
   "description": "A typeahead/autocomplete component for Vue 2 using Bootstrap 4",
   "keywords": [

--- a/src/components/VueTypeaheadBootstrap.vue
+++ b/src/components/VueTypeaheadBootstrap.vue
@@ -55,7 +55,7 @@
       :showOnFocus="showOnFocus"
       :showAllResults="showAllResults"
       @hit="handleHit"
-      @hitAppend="handleHitAppend"
+      @hitListAppend="handlehitListAppend"
       @listItemBlur="handleChildBlur"
       :highlightClass='highlightClass'
       :disabledValues="disabledValues"
@@ -212,8 +212,8 @@ export default {
       }
     },
 
-    handleHitAppend(evt) {
-      this.$emit('hitAppend', evt)
+    handlehitListAppend(evt) {
+      this.$emit('hitListAppend', evt)
 
       if (this.autoClose) {
         this.$refs.input.blur()

--- a/src/components/VueTypeaheadBootstrap.vue
+++ b/src/components/VueTypeaheadBootstrap.vue
@@ -44,7 +44,7 @@
       :id="`result-list-${id}`"
       class="vbt-autcomplete-list"
       ref="list"
-      v-show="isFocused && (!!data.length || !!$slots.listAppend)"
+      v-show="isFocused && (!!data.length || $scopedSlots.listAppend)"
       :query="inputValue"
       :data="formattedData"
       :background-variant="backgroundVariant"

--- a/src/components/VueTypeaheadBootstrap.vue
+++ b/src/components/VueTypeaheadBootstrap.vue
@@ -44,7 +44,7 @@
       :id="`result-list-${id}`"
       class="vbt-autcomplete-list"
       ref="list"
-      v-show="isFocused && data.length > 0"
+      v-show="isFocused && (!!data.length || !!$slots.listAppend)"
       :query="inputValue"
       :data="formattedData"
       :background-variant="backgroundVariant"

--- a/src/components/VueTypeaheadBootstrap.vue
+++ b/src/components/VueTypeaheadBootstrap.vue
@@ -55,6 +55,7 @@
       :showOnFocus="showOnFocus"
       :showAllResults="showAllResults"
       @hit="handleHit"
+      @hitAppend="handleHitAppend"
       @listItemBlur="handleChildBlur"
       :highlightClass='highlightClass'
       :disabledValues="disabledValues"
@@ -204,6 +205,15 @@ export default {
 
       this.inputValue = evt.text
       this.$emit('hit', evt.data)
+
+      if (this.autoClose) {
+        this.$refs.input.blur()
+        this.isFocused = false
+      }
+    },
+
+    handleHitAppend(evt) {
+      this.$emit('hitAppend', evt)
 
       if (this.autoClose) {
         this.$refs.input.blur()

--- a/src/components/VueTypeaheadBootstrap.vue
+++ b/src/components/VueTypeaheadBootstrap.vue
@@ -55,7 +55,7 @@
       :showOnFocus="showOnFocus"
       :showAllResults="showAllResults"
       @hit="handleHit"
-      @hitListAppend="handlehitListAppend"
+      @hitListAppend="handleHitListAppend"
       @listItemBlur="handleChildBlur"
       :highlightClass='highlightClass'
       :disabledValues="disabledValues"
@@ -212,7 +212,7 @@ export default {
       }
     },
 
-    handlehitListAppend(evt) {
+    handleHitListAppend(evt) {
       this.$emit('hitListAppend', evt)
 
       if (this.autoClose) {

--- a/src/components/VueTypeaheadBootstrapList.vue
+++ b/src/components/VueTypeaheadBootstrapList.vue
@@ -18,12 +18,22 @@
       <template v-if="$scopedSlots.suggestion" slot="suggestion" slot-scope="{ data, htmlText }">
         <slot name="suggestion" v-bind="{ data, htmlText }" />
       </template>
+
     </vue-typeahead-bootstrap-list-item>
+
+    <vue-typeahead-bootstrap-list-append
+      v-if="$scopedSlots.listAppend" 
+      v-bind="{ query, backgroundVariant, textVariant }"
+      @hitAppend="$emit('hitAppend', $event)"
+    >
+      <slot name="listAppend" />
+    </vue-typeahead-bootstrap-list-append>
   </div>
 </template>
 
 <script>
 import VueTypeaheadBootstrapListItem from './VueTypeaheadBootstrapListItem.vue'
+import VueTypeaheadBootstrapListAppend from './VueTypeaheadBootstrapListAppend.vue'
 import clone from 'lodash/clone'
 import includes from 'lodash/includes'
 import isEmpty from 'lodash/isEmpty'
@@ -45,7 +55,8 @@ export default {
   name: 'VueTypeaheadBootstrapList',
 
   components: {
-    VueTypeaheadBootstrapListItem
+    VueTypeaheadBootstrapListItem,
+    VueTypeaheadBootstrapListAppend
   },
 
   props: {

--- a/src/components/VueTypeaheadBootstrapList.vue
+++ b/src/components/VueTypeaheadBootstrapList.vue
@@ -24,7 +24,7 @@
     <vue-typeahead-bootstrap-list-append
       v-if="$scopedSlots.listAppend" 
       v-bind="{ query, backgroundVariant, textVariant }"
-      @hitAppend="$emit('hitAppend', $event)"
+      @hitListAppend="$emit('hitListAppend', $event)"
     >
       <slot name="listAppend" />
     </vue-typeahead-bootstrap-list-append>

--- a/src/components/VueTypeaheadBootstrapListAppend.vue
+++ b/src/components/VueTypeaheadBootstrapListAppend.vue
@@ -3,7 +3,7 @@
     tabindex="0"
     href="#"
     :class="textClasses"
-    @click.prevent="$emit('hitAppend', query)"
+    @click.prevent="$emit('hitListAppend', query)"
   >
     <div aria-hidden="true">
       <slot v-bind="{ query }" />

--- a/src/components/VueTypeaheadBootstrapListAppend.vue
+++ b/src/components/VueTypeaheadBootstrapListAppend.vue
@@ -6,7 +6,7 @@
     @click.prevent="$emit('hitListAppend', query)"
   >
     <div aria-hidden="true">
-      <slot v-bind="{ query }" />
+      <slot />
     </div>
   </a>
 </template>

--- a/src/components/VueTypeaheadBootstrapListAppend.vue
+++ b/src/components/VueTypeaheadBootstrapListAppend.vue
@@ -44,3 +44,4 @@ export default {
   a {
     cursor: pointer;
   }
+</style>

--- a/src/components/VueTypeaheadBootstrapListAppend.vue
+++ b/src/components/VueTypeaheadBootstrapListAppend.vue
@@ -1,0 +1,46 @@
+<template>
+  <a
+    tabindex="0"
+    href="#"
+    :class="textClasses"
+    @click.prevent="$emit('hitAppend', query)"
+  >
+    <div aria-hidden="true">
+      <slot v-bind="{ query }" />
+    </div>
+  </a>
+</template>
+
+<script>
+export default {
+  name: 'VueTypeaheadBootstrapListAppend',
+
+  props: {
+    query: {
+      type: String
+    },
+    backgroundVariant: {
+      type: String
+    },
+    textVariant: {
+      type: String
+    }
+  },
+
+  computed: {
+    textClasses() {
+      const classes = ['vbst-item', 'list-group-item', 'list-group-item-action']
+      
+      if (this.backgroundVariant) classes.push(`bg-${this.backgroundVariant}`)
+      if (this.textVariant) classes.push(`text-${this.textVariant}`)
+
+      return classes.join(' ')
+    }
+  }
+}
+</script>
+
+<style scoped>
+  a {
+    cursor: pointer;
+  }

--- a/tests/unit/VueTypeaheadBootstrap.spec.js
+++ b/tests/unit/VueTypeaheadBootstrap.spec.js
@@ -129,4 +129,15 @@ describe('VueTypeaheadBootstrap', () => {
       expect(selectPreviousListItem).toHaveBeenCalledWith()
     })
   })
+
+  it('Emits `hitListAppend` event from `VueTypeaheadBootstrapList`', async () => {
+    const query = 'Query'
+    wrapper.setProps({ query })
+    await wrapper.vm.$nextTick()
+    
+    wrapper.findComponent({name: 'VueTypeaheadBootstrapList'}).vm.$emit('hitListAppend', query)
+
+    expect(wrapper.emitted('hitListAppend')).toHaveLength(1)
+    expect(wrapper.emitted('hitListAppend')[0][0]).toBe(query)
+  })
 })

--- a/tests/unit/VueTypeaheadBootstrapList.spec.js
+++ b/tests/unit/VueTypeaheadBootstrapList.spec.js
@@ -1,4 +1,4 @@
-import { mount } from '@vue/test-utils'
+import { mount, shallowMount } from '@vue/test-utils'
 import VueTypeaheadBootstrapList from '@/components/VueTypeaheadBootstrapList.vue'
 import VueTypeaheadBootstrapListItem from '@/components/VueTypeaheadBootstrapListItem.vue'
 
@@ -217,5 +217,43 @@ describe('VueBootstrapTypeaheadList', () => {
     })
     await wrapper.vm.$nextTick()
     expect(wrapper.findComponent(VueTypeaheadBootstrapListItem).vm.htmlText).toBe(`<span class='myStyle'>Canada</span>`)
+  })
+
+})
+
+describe('VueBootstrapTypeaheadList - List append slot', () => {
+  const propsData = { data: [], vbtUniqueId: 123456789 }
+  const listAppendSlot = () => 'Test'
+
+  it.each([undefined, listAppendSlot])('Renders `VueTypeaheadBootstrapListAppend` if slot used', (listAppend) => {
+    const wrapper = shallowMount(VueTypeaheadBootstrapList, { 
+      propsData, scopedSlots: { ...listAppend && {listAppend} }
+    })
+    const shouldRenderComponent = !!listAppend
+
+    expect(wrapper.findComponent({name: 'VueTypeaheadBootstrapListAppend'}).exists()).toBe(shouldRenderComponent)
+  })
+
+  it('Passes props to `VueTypeaheadBootstrapListAppend`', () => {
+    const componentProps = { query: 'Query', backgroundVariant: 'bg', textVariant: 'text' }
+    const wrapper = shallowMount(VueTypeaheadBootstrapList, { 
+      propsData: { ...propsData, ...componentProps }, scopedSlots: { listAppend: listAppendSlot }
+    })
+    const component = wrapper.findComponent({name: 'VueTypeaheadBootstrapListAppend'})
+
+    expect(component.props()).toEqual(componentProps)
+  })
+
+  it('Emits `hitListAppend` event from `VueTypeaheadBootstrapListAppend`', () => {
+    const query = 'Query'
+    const wrapper = shallowMount(VueTypeaheadBootstrapList, { 
+      propsData: { ...propsData, query }, scopedSlots: { listAppend: listAppendSlot }
+    })
+    const component = wrapper.findComponent({name: 'VueTypeaheadBootstrapListAppend'})
+
+    component.vm.$emit('hitListAppend', query)
+
+    expect(wrapper.emitted('hitListAppend')).toHaveLength(1)
+    expect(wrapper.emitted('hitListAppend')[0][0]).toBe(query)
   })
 })

--- a/tests/unit/VueTypeaheadBootstrapListAppend.spec.js
+++ b/tests/unit/VueTypeaheadBootstrapListAppend.spec.js
@@ -1,0 +1,37 @@
+import { shallowMount } from '@vue/test-utils'
+import VueTypeaheadBootstrapListAppend from '@/components/VueTypeaheadBootstrapListAppend.vue'
+
+describe('VueTypeaheadBootstrapListAppend.vue', () => {
+  let wrapper
+  beforeEach(() => {
+    wrapper = shallowMount(VueTypeaheadBootstrapListAppend)
+  })
+
+  it('Mounts and renders an <a> tag', () => {
+    expect(wrapper.exists()).toBe(true)
+    expect(wrapper.element.tagName.toLowerCase()).toBe('a')
+  })
+
+  it('Renders textVariant classes properly', async () => {
+    wrapper.setProps({ textVariant: 'dark' })
+    await wrapper.vm.$nextTick()
+    expect(wrapper.classes()).toEqual(expect.arrayContaining(['text-dark']))
+  })
+
+  it('Renders backgroundVariant classes properly', async () => {
+    wrapper.setProps({ backgroundVariant: 'light' })
+    await wrapper.vm.$nextTick()
+    expect(wrapper.classes()).toEqual(expect.arrayContaining(['bg-light']))
+  })
+
+  it('Emits `hitListAppend` event with query on click', async () => {
+    const query = 'TestQuery'
+    wrapper.setProps({query})
+    await wrapper.vm.$nextTick()
+
+    wrapper.trigger('click')
+
+    expect(wrapper.emitted('hitListAppend')).toHaveLength(1)
+    expect(wrapper.emitted('hitListAppend')[0][0]).toBe(query)
+  })
+})


### PR DESCRIPTION
Additional slot, when used, appends list item to autocomplete list. Emits `hitListAppend` event with query on click, For example, you can use it to add non existing resource (using query).

Really need this feature and workarounds are terrible to use, so I've added it and hope everyone will make use of it.

Docs and tests updated.