### PR TITLE
Feature - Select first result on enter

### DIFF
--- a/docs/guide/reference.md
+++ b/docs/guide/reference.md
@@ -29,7 +29,7 @@
 
 Name | Description
 | --- | --- |
-hit | Triggered when an autocomplete item is selected. The entry in the input data array that was selected is returned.
+hit | Triggered when an autocomplete item is selected. The entry in the input data array that was selected is returned. If no autocomplete item is selected, the first entry matching the query is selected and returned.
 input | The component can be used with `v-model`
 keyup | Triggered when any keyup event is fired in the input. Often used for catching `keyup.enter`.
 

--- a/src/components/VueTypeaheadBootstrapList.vue
+++ b/src/components/VueTypeaheadBootstrapList.vue
@@ -287,6 +287,9 @@ export default {
       evt.preventDefault()
     },
     hitActiveListItem() {
+      if (this.activeListItem < 0) {
+        this.selectNextListItem();
+      }
       if (this.activeListItem >= 0) {
         this.$emit('hit', this.matchedItems[this.activeListItem])
       }

--- a/tests/unit/VueTypeaheadBootstrapList.spec.js
+++ b/tests/unit/VueTypeaheadBootstrapList.spec.js
@@ -88,7 +88,7 @@ describe('VueBootstrapTypeaheadList', () => {
         id: 1,
         data: 'amélie poulain',
         text: 'amélie poulain'
-      },
+      }
     ]
 
     wrapper = mount(VueTypeaheadBootstrapList, {
@@ -167,13 +167,13 @@ describe('VueBootstrapTypeaheadList', () => {
           id: 0,
           data: 'amélie',
           text: 'amélie'
-        },
+        }
       ],
       query: 'ame'
     })
     await wrapper.vm.$nextTick()
     expect(wrapper.findComponent(VueTypeaheadBootstrapListItem).vm.htmlText).toBe(`<span class='vbt-matched-text'>amé</span>lie`)
-  });
+  })
 
   it('Highlights text matches correctly when the query contains accents and the data does not', async () => {
     wrapper.setProps({
@@ -182,13 +182,13 @@ describe('VueBootstrapTypeaheadList', () => {
           id: 0,
           data: 'amelie',
           text: 'amelie'
-        },
+        }
       ],
       query: 'amé'
     })
     await wrapper.vm.$nextTick()
     expect(wrapper.findComponent(VueTypeaheadBootstrapListItem).vm.htmlText).toBe(`<span class='vbt-matched-text'>ame</span>lie`)
-  });
+  })
 
   describe('selecting items with the keyboard', () => {
     beforeEach(() => {
@@ -302,6 +302,98 @@ describe('VueBootstrapTypeaheadList', () => {
         wrapper.vm.selectPreviousListItem()
         expect(wrapper.vm.activeListItem).toBe(1)
       })
+    })
+  })
+
+  describe('Selecting on Enter Key', () => {
+    beforeEach(() => {
+      wrapper.setProps({
+        data: [
+          {
+            id: 0,
+            data: 'Canada',
+            text: 'Canada'
+          },
+          {
+            id: 1,
+            data: 'Canada1',
+            text: 'Canada1'
+          },
+          {
+            id: 2,
+            data: 'Canada2',
+            text: 'Canada2'
+          }
+        ]
+      })
+    })
+
+    it('does not return a hit with no matches', async () => {
+      wrapper.setProps({
+        query: ';lskdj'
+      })
+      await wrapper.vm.$nextTick()
+      wrapper.vm.handleParentInputKeyup({keyCode: 13}) // simulate enter key
+      await wrapper.vm.$nextTick()
+      expect(wrapper.emitted('hit')).toBeFalsy()
+    })
+
+    describe('with some matches', () => {
+      beforeEach(() => {
+        wrapper.setProps({
+          query: 'Cana'
+        })
+      })
+      it('returns the selected item when one is selected', async () => {
+        wrapper.vm.selectNextListItem()
+        wrapper.vm.selectNextListItem()
+        await wrapper.vm.$nextTick()
+        wrapper.vm.handleParentInputKeyup({keyCode: 13}) // simulate enter key
+        await wrapper.vm.$nextTick()
+        expect(wrapper.emitted().hit).toBeTruthy()
+        expect(wrapper.emitted().hit[0][0].id).toBe(1)
+      })
+
+      it('returns the first item when no item is selected', async () => {
+        await wrapper.vm.$nextTick()
+        wrapper.vm.handleParentInputKeyup({keyCode: 13}) // simulate enter key
+        await wrapper.vm.$nextTick()
+        expect(wrapper.emitted().hit).toBeTruthy()
+        expect(wrapper.emitted().hit[0][0].id).toBe(0)
+      })
+
+      it('returns the first enabled item when no item is selected', async () => {
+        wrapper.setProps({
+          disabledValues: ['Canada']
+        })
+        wrapper.vm.handleParentInputKeyup({keyCode: 13}) // simulate enter key
+        await wrapper.vm.$nextTick()
+        expect(wrapper.emitted().hit).toBeTruthy()
+        expect(wrapper.emitted().hit[0][0].id).toBe(1)
+      })
+    })
+
+    it('returns the only non-disabled item as a hit with only one enabled match', async () => {
+      wrapper.setProps({
+        disabledValues: ['Canada', 'Canada2'],
+        query: 'Cana'
+      })
+      await wrapper.vm.$nextTick()
+      wrapper.vm.handleParentInputKeyup({keyCode: 13}) // simulate enter key
+      await wrapper.vm.$nextTick()
+      expect(wrapper.emitted().hit).toBeTruthy()
+      expect(wrapper.emitted().hit[0][0].id).toBe(1)
+    })
+
+    it('does not return a hit with only disabled matches', async () => {
+      wrapper.setProps({
+        disabledValues: ['Canada', 'Canada1', 'Canada2'],
+        query: 'Cana'
+      })
+      await wrapper.vm.$nextTick()
+      wrapper.vm.handleParentInputKeyup({keyCode: 13}) // simulate enter key
+      await wrapper.vm.$nextTick()
+      expect(wrapper.emitted('hit')).toBeFalsy()
     })
   })
 


### PR DESCRIPTION
Resolving issue #67

The change is fairly simple, just select the first matched item if we don't already have an active item.

I've also added unit tests to verify the expected behaviour and amended the docs to reflect the change in behaviour.

Eslint auto-fixed some stray commas in the test file and I left those changes in.