### PR TITLE
Improve screen reader text support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.11.1 - 23 Apr 2021
+- Improve screen reader text support
+
 ## 2.11.0 - 7 Apr 2021
 - Rebuild dist files that were missed in previous two versions (2.9.0 & 2.10.0)
 

--- a/docs/.vuepress/components/CustomSuggestion.vue
+++ b/docs/.vuepress/components/CustomSuggestion.vue
@@ -8,6 +8,7 @@
       v-model="query"
       :data="users"
       :serializer="item => item.login"
+      :screen-reader-text-serializer="item => `Github user ${item.login}`"
       highlightClass="special-highlight-class"
       @hit="selecteduser = $event"
       :minMatchingChars="3"

--- a/docs/examples/examples.md
+++ b/docs/examples/examples.md
@@ -149,6 +149,7 @@
       v-model="query"
       :data="users"
       :serializer="item => item.login"
+      :screen-reader-text-serializer="item => `Github user ${item.login}`"
       highlightClass="special-highlight-class"
       @hit="selecteduser = $event"
       :minMatchingChars="3"

--- a/docs/guide/reference.md
+++ b/docs/guide/reference.md
@@ -19,6 +19,7 @@
 | maxMatches | Number | 10 | Maximum amount of list items to appear.
 | minMatchingChars | Number | 2 | Minimum matching characters in query before the typeahead list appears
 | prepend | String | | Text to be prepended to the `input-group`
+| screenReaderTextSerializer | Function | `input => input`| Function used to convert the entries in the data array into the screen reader text string. Falls back to the value of serializer.|
 | serializer | Function | `input => input`| Function used to convert the entries in the data array into a text string. |
 | showAllResults | `Boolean` | false | Show all results even ones that highlighting doesn't match. This is useful when interacting with a API that returns results based on different values than what is displayed. Ex: user searches for "USA" and the service returns "United States of America".
 | showOnFocus | `Boolean` | false | Show results as soon as the input gains focus before the user has typed anything.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-typeahead-bootstrap",
-  "version": "2.11.0",
+  "version": "2.11.1",
   "private": false,
   "description": "A typeahead/autocomplete component for Vue 2 using Bootstrap 4",
   "keywords": [

--- a/src/components/VueTypeaheadBootstrap.vue
+++ b/src/components/VueTypeaheadBootstrap.vue
@@ -112,6 +112,12 @@ export default {
       default: (d) => d,
       validator: d => d instanceof Function
     },
+    // Don't call this method, use _screenReaderTextSerializer()
+    // Using _screenReaderTextSerializer allows for defaulting based on .serializer
+    screenReaderTextSerializer: {
+      type: Function,
+      validator: d => d instanceof Function
+    },
     backgroundVariant: String,
     backgroundVariantResolver: {
       type: Function,
@@ -181,6 +187,7 @@ export default {
         return {
           id: i,
           data: d,
+          screenReaderText: this._screenReaderTextSerializer(d),
           text: this.serializer(d)
         }
       })
@@ -188,6 +195,17 @@ export default {
   },
 
   methods: {
+    _screenReaderTextSerializer(d){
+      if ( typeof d === "object" && !Array.isArray(d) && d !== null){
+       if (this.screenReaderTextSerializer){
+          return this.screenReaderTextSerializer(d)
+        } else {
+          return this.serializer(d)
+        }
+      } else {
+        return d
+      }
+    },
     resizeList(el) {
       const rect = el.getBoundingClientRect()
       const listStyle = this.$refs.list.$el.style

--- a/tests/unit/VueTypeaheadBootstrap.spec.js
+++ b/tests/unit/VueTypeaheadBootstrap.spec.js
@@ -36,6 +36,50 @@ describe('VueTypeaheadBootstrap', () => {
     expect(wrapper.vm.formattedData[0].text).toBe('Canada')
   })
 
+  it('Defaults the screenReaderTextSerializer to the text for arrays', () => {
+    wrapper = mount(VueTypeaheadBootstrap, {
+      propsData: {
+        data: ['Canada','CA']
+      }
+    })
+    expect(wrapper.vm.formattedData[0].screenReaderText).toBe('Canada')
+    expect(wrapper.vm.formattedData[1].screenReaderText).toBe('CA')
+  })
+
+  it('Defaults the screenReaderTextSerializer to the value of the serializer', () => {
+    wrapper = mount(VueTypeaheadBootstrap, {
+      propsData: {
+        data: [{
+          name: 'Canada',
+          code: 'CA'
+        }],
+        value: 'Can',
+        serializer: t => t.name,
+      }
+    })
+    expect(wrapper.vm.formattedData[0].id).toBe(0)
+    expect(wrapper.vm.formattedData[0].data.code).toBe('CA')
+    expect(wrapper.vm.formattedData[0].screenReaderText).toBe('Canada')
+  })
+
+  it('Uses a custom screenReaderTextSerializer properly', () => {
+    wrapper = mount(VueTypeaheadBootstrap, {
+      propsData: {
+        data: [{
+          name: 'Canada',
+          screenReaderText: 'Canada button',
+          code: 'CA'
+        }],
+        value: 'Can',
+        screenReaderTextSerializer: t => t.screenReaderText,
+        serializer: t => t.name,
+      }
+    })
+    expect(wrapper.vm.formattedData[0].id).toBe(0)
+    expect(wrapper.vm.formattedData[0].data.code).toBe('CA')
+    expect(wrapper.vm.formattedData[0].screenReaderText).toBe('Canada button')
+  })
+
   it('Uses a custom serializer properly', () => {
     wrapper = mount(VueTypeaheadBootstrap, {
       propsData: {

--- a/tests/unit/VueTypeaheadBootstrapList.spec.js
+++ b/tests/unit/VueTypeaheadBootstrapList.spec.js
@@ -219,7 +219,6 @@ describe('VueBootstrapTypeaheadList', () => {
         query: 'Can'
       })
       await wrapper.vm.$nextTick()
-      console.log(wrapper.findComponent(VueTypeaheadBootstrapListItem).vm.screenReaderText)
       expect(wrapper.findComponent(VueTypeaheadBootstrapListItem).vm.screenReaderText).toBe('my screen reader text')
     })
 


### PR DESCRIPTION
We needed to pass the screen reader text down into the list then into
the item. To follow the established convention, we added a screen reader
serializer allowing users to declare where to find there screen reader
text.

In an effort to provide sensible defaults we default screen reader text
to the output of the serializer if it exists for an object or just the
text if we're working with an array of strings.