### PR TITLE
escape string before passing to RegExp

### DIFF
--- a/src/components/VueTypeaheadBootstrapList.vue
+++ b/src/components/VueTypeaheadBootstrapList.vue
@@ -228,7 +228,7 @@ export default {
         }
       }
 
-      return new RegExp(regexp, 'gi')
+      return new RegExp(escapeRegExp(regexp), 'gi')
     },
 
     escapedQuery() {


### PR DESCRIPTION
issue: https://github.com/mattzollinhofer/vue-typeahead-bootstrap/issues/115

I was able to repro locally that this fixes any input using special regex characters, in my case it was `(` and `)`. I kept getting errors trying to run this repo locally (is `yarn serve` correct?), so I may need help with a good unit test for this.