### PR TITLE
focustFirst option

### DIFF
--- a/docs/guide/reference.md
+++ b/docs/guide/reference.md
@@ -23,6 +23,7 @@
 | serializer | Function | `input => input`| Function used to convert the entries in the data array into a text string. |
 | showAllResults | `Boolean` | false | Show all results even ones that highlighting doesn't match. This is useful when interacting with a API that returns results based on different values than what is displayed. Ex: user searches for "USA" and the service returns "United States of America".
 | showOnFocus | `Boolean` | false | Show results as soon as the input gains focus before the user has typed anything.
+| focusFirst | `Boolean` | true | Option to disable first item auto selection, so user can enter free search queries by setting false.
 | size | String | | Size of the `input-group`. Valid values: `sm`, `md`, or `lg` |
 | textVariant | String | | Text color for autocomplete result `list-group` items. [See values here.][2]
 

--- a/src/components/VueTypeaheadBootstrap.vue
+++ b/src/components/VueTypeaheadBootstrap.vue
@@ -237,8 +237,6 @@ export default {
       this.$emit('hit', evt.data)
 
 
-      console.log(evt,this.autoClose);
-
       if (this.autoClose) {
         this.$refs.input.blur()
         this.isFocused = false
@@ -274,11 +272,12 @@ export default {
       if (typeof this.value !== 'undefined') {
         this.$emit('input', newValue)
       }
+      else{
+        this.$emit('input', "")
+      }
     },
 
     handleEsc(inputValue) {
-
-      console.log("handleEsc",inputValue);
 
       
       if (inputValue === '') {

--- a/src/components/VueTypeaheadBootstrap.vue
+++ b/src/components/VueTypeaheadBootstrap.vue
@@ -60,7 +60,9 @@
       :highlightClass='highlightClass'
       :disabledValues="disabledValues"
       :vbtUniqueId="id"
+      :focusFirst="focusFirst"
       role="listbox"
+
     >
       <!-- pass down all scoped slots -->
       <template v-for="(slot, slotName) in $scopedSlots" :slot="slotName" slot-scope="{ data, htmlText }">
@@ -153,6 +155,10 @@ export default {
       type: Boolean,
       default: false
     },
+    focusFirst: {
+      type: Boolean,
+      default: true
+    },
     showAllResults: {
       type: Boolean,
       default: false
@@ -222,12 +228,16 @@ export default {
     },
 
     handleHit(evt) {
+
       if (typeof this.value !== 'undefined') {
         this.$emit('input', evt.text)
       }
 
       this.inputValue = evt.text
       this.$emit('hit', evt.data)
+
+
+      console.log(evt,this.autoClose);
 
       if (this.autoClose) {
         this.$refs.input.blur()
@@ -267,6 +277,10 @@ export default {
     },
 
     handleEsc(inputValue) {
+
+      console.log("handleEsc",inputValue);
+
+      
       if (inputValue === '') {
         this.$refs.input.blur()
         this.isFocused = false

--- a/src/components/VueTypeaheadBootstrapList.vue
+++ b/src/components/VueTypeaheadBootstrapList.vue
@@ -97,6 +97,10 @@ export default {
       type: Boolean,
       default: false
     },
+    focusFirst: {
+      type: Boolean,
+      default: true
+    },
     highlightClass: {
       type: String,
       default: 'vbt-matched-text'
@@ -179,9 +183,13 @@ export default {
       evt.preventDefault()
     },
     hitActiveListItem() {
-      if (this.activeListItem < 0) {
+      if(!this.focusFirst){
+        this.$emit('hit', "");
+      }
+      else if (this.activeListItem < 0) {
         this.selectNextListItem();
       }
+
       if (this.activeListItem >= 0) {
         this.$emit('hit', this.matchedItems[this.activeListItem])
       }
@@ -227,7 +235,9 @@ export default {
         return true
       }
 
-      this.activeListItem = this.findIndexForNextActiveItem()
+      this.activeListItem = this.findIndexForNextActiveItem();
+
+
     },
 
     selectPreviousListItem() {


### PR DESCRIPTION
Currently typehead is not allowing to enter free search, for example if you type for ind ("india") but list if list has only has "indonesia" then it automatically selects the first item. But as like google search it should allow us to enter free search query 
Option to disable first item auto selection, so user can enter free search queries by setting `focustFirst` option as false.

Hope this is useful to others