### PR TITLE
Allows custom matcher and highlighter functions to be provided

### DIFF
--- a/src/components/VueTypeaheadBootstrap.vue
+++ b/src/components/VueTypeaheadBootstrap.vue
@@ -47,6 +47,8 @@
       v-show="isFocused && data.length > 0"
       :query="inputValue"
       :data="formattedData"
+      :matcher="matcher"
+      :highlighter="highlighter"
       :background-variant="backgroundVariant"
       :background-variant-resolver="backgroundVariantResolver"
       :text-variant="textVariant"
@@ -110,6 +112,14 @@ export default {
     serializer: {
       type: Function,
       default: (d) => d,
+      validator: d => d instanceof Function
+    },
+    matcher: {
+      type: Function,
+      validator: d => d instanceof Function
+    },
+    highlighter: {
+      type: Function,
       validator: d => d instanceof Function
     },
     // Don't call this method, use _screenReaderTextSerializer()


### PR DESCRIPTION
Resolves #46 

This adds two new props to VueTypeaheadBootstrap and VueTypeaheadBootstrapList for "matcher" and "highlighter". The former just passes them along to the latter for use.

Then in the list component it will use those, if present, and otherwise fallback on the default matching and highlighting that was there before.

All you need to do to use this is create your custom matcher and/or highlighter functions, import those into your vue file that's implementing this component and specify those functions in the properties of the component in your vue template.